### PR TITLE
Secure connection, certificate checking and one reference request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,18 +192,18 @@
                 <executions>
                     <execution>
                         <id>email-library</id>
-                        <phase>compile</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>attached</goal>
                         </goals>
                         <configuration>
                             <finalName>${connector.name}-connector-${version}</finalName>
-                            <appendAssemblyId>false</appendAssemblyId>
+                            <appendAssemblyId>true</appendAssemblyId>
                             <filters>
-                                <filter>src/main/assembly/filter.properties</filter>
+                                <filter>${basedir}/src/main/assembly/filter.properties</filter>
                             </filters>
                             <descriptors>
-                                <descriptor>src/main/assembly/assemble-connector.xml</descriptor>
+                                <descriptor>${basedir}/src/main/assembly/assemble-connector.xml</descriptor>
                             </descriptors>
                         </configuration>
                     </execution>

--- a/src/main/java/org/wso2/carbon/connector/ldap/Authenticate.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/Authenticate.java
@@ -59,9 +59,7 @@ public class Authenticate extends AbstractConnector {
         if(secureConnection)
         	env.put(Context.SECURITY_PROTOCOL, "ssl");
         if(disableSSLCertificateChecking)
-        	env.put("java.naming.ldap.factory.socket", "org.wso2.carbon.connector.security.MySSLSocketFactory");        
-
-        org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        	env.put("java.naming.ldap.factory.socket", "org.wso2.carbon.connector.security.MySSLSocketFactory");
 
         boolean logged = false;
         DirContext ctx = null;

--- a/src/main/java/org/wso2/carbon/connector/ldap/Authenticate.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/Authenticate.java
@@ -43,6 +43,8 @@ public class Authenticate extends AbstractConnector {
         String providerUrl = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.PROVIDER_URL);
         String dn = (String) getParameter(messageContext, "dn");
         String password = (String) getParameter(messageContext, "password");
+        boolean secureConnection = Boolean.valueOf(LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURE_CONNECTION));
+        boolean disableSSLCertificateChecking = Boolean.valueOf(LDAPUtils.lookupContextParams(messageContext, LDAPConstants.DISABLE_SSL_CERT_CHECKING));
 
         OMFactory factory = OMAbstractFactory.getOMFactory();
         OMNamespace ns = factory.createOMNamespace(LDAPConstants.CONNECTOR_NAMESPACE, "ns");
@@ -54,6 +56,10 @@ public class Authenticate extends AbstractConnector {
         env.put(Context.PROVIDER_URL, providerUrl);
         env.put(Context.SECURITY_PRINCIPAL, dn);
         env.put(Context.SECURITY_CREDENTIALS, password);
+        if(secureConnection)
+        	env.put(Context.SECURITY_PROTOCOL, "ssl");
+        if(disableSSLCertificateChecking)
+        	env.put("java.naming.ldap.factory.socket", "org.wso2.carbon.connector.security.MySSLSocketFactory");        
 
         org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext) messageContext).getAxis2MessageContext();
 

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.connector.ldap;
 
 public class LDAPConstants {
+	public static final String SECURE_CONNECTION = "secureConnection";
+	public static final String DISABLE_SSL_CERT_CHECKING = "disableSSLCertificateChecking";	
     public static final String PROVIDER_URL = "providerUrl";
     public static final String SECURITY_PRINCIPAL = "securityPrincipal";
     public static final String SECURITY_CREDENTIALS = "securityCredentials";

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
@@ -26,7 +26,6 @@ import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 
-
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
@@ -48,6 +47,8 @@ public class LDAPUtils {
         String providerUrl = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.PROVIDER_URL);
         String securityPrincipal = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURITY_PRINCIPAL);
         String securityCredentials = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURITY_CREDENTIALS);
+        boolean secureConnection = Boolean.valueOf(LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURE_CONNECTION));
+        boolean disableSSLCertificateChecking = Boolean.valueOf(LDAPUtils.lookupContextParams(messageContext, LDAPConstants.DISABLE_SSL_CERT_CHECKING));        
 
         Hashtable env = new Hashtable();
         env.put(Context.INITIAL_CONTEXT_FACTORY,
@@ -56,6 +57,10 @@ public class LDAPUtils {
         env.put(Context.PROVIDER_URL, providerUrl);
         env.put(Context.SECURITY_PRINCIPAL, securityPrincipal);
         env.put(Context.SECURITY_CREDENTIALS, securityCredentials);
+        if(secureConnection)
+        	env.put(Context.SECURITY_PROTOCOL, "ssl");
+        if(disableSSLCertificateChecking)
+        	env.put("java.naming.ldap.factory.socket", "org.wso2.carbon.connector.security.MySSLSocketFactory");                
 
         DirContext ctx = null;
         ctx = new InitialDirContext(env);

--- a/src/main/java/org/wso2/carbon/connector/security/DummyTrustmanager.java
+++ b/src/main/java/org/wso2/carbon/connector/security/DummyTrustmanager.java
@@ -1,0 +1,20 @@
+package org.wso2.carbon.connector.security;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509TrustManager;
+
+public class DummyTrustmanager implements X509TrustManager {
+    public void checkClientTrusted(X509Certificate[] xcs, String string) throws CertificateException {
+        // do nothing
+    }
+
+    public void checkServerTrusted(X509Certificate[] xcs, String string) throws CertificateException {
+        // do nothing
+    }
+
+    public X509Certificate[] getAcceptedIssuers() {
+        return new java.security.cert.X509Certificate[0];
+    }
+}

--- a/src/main/java/org/wso2/carbon/connector/security/MySSLSocketFactory.java
+++ b/src/main/java/org/wso2/carbon/connector/security/MySSLSocketFactory.java
@@ -1,0 +1,67 @@
+package org.wso2.carbon.connector.security;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.SecureRandom;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+public class MySSLSocketFactory extends SSLSocketFactory {
+    private SSLSocketFactory socketFactory;
+
+    public MySSLSocketFactory() {
+        try {
+            SSLContext ctx = SSLContext.getInstance("TLS");
+            ctx.init(null, new TrustManager[] { new DummyTrustmanager() }, new SecureRandom());
+            socketFactory = ctx.getSocketFactory();
+        } catch (Exception ex) {
+            ex.printStackTrace(System.err);
+            /* handle exception */
+        }
+    }
+
+    public static SocketFactory getDefault() {
+        return new MySSLSocketFactory();
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return socketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return socketFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String string, int i, boolean bln) throws IOException {
+        return socketFactory.createSocket(socket, string, i, bln);
+    }
+
+    @Override
+    public Socket createSocket(String string, int i) throws IOException, UnknownHostException {
+        return socketFactory.createSocket(string, i);
+    }
+
+    @Override
+    public Socket createSocket(String string, int i, InetAddress ia, int i1) throws IOException, UnknownHostException {
+        return socketFactory.createSocket(string, i, ia, i1);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress ia, int i) throws IOException {
+        return socketFactory.createSocket(ia, i);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress ia, int i, InetAddress ia1, int i1) throws IOException {
+        return socketFactory.createSocket(ia, i, ia1, i1);
+    }
+
+}

--- a/src/main/resources/ldap_auth/authenticate.xml
+++ b/src/main/resources/ldap_auth/authenticate.xml
@@ -1,29 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
-~
-~  WSO2 Inc. licenses this file to you under the Apache License,
-~  Version 2.0 (the "License"); you may not use this file except
-~  in compliance with the License.
-~  You may obtain a copy of the License at
-~
-~   http://www.apache.org/licenses/LICENSE-2.0
-~
-~  Unless required by applicable law or agreed to in writing,
-~  software distributed under the License is distributed on an
-~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~  KIND, either express or implied.  See the License for the
-~  specific language governing permissions and limitations
-~  under the License.
--->
-<template xmlns="http://ws.apache.org/ns/synapse" name="authenticate">
-    <parameter name="dn"
-               description="username of the user used to log in to LDAP."/>
-    <parameter name="password"
-               description="password of the user used to log in to LDAP."/>
-    <sequence>
-        <property name="dn" expression="$func:dn"/>
-        <property name="password" expression="$func:password"/>
-        <class name="org.wso2.carbon.connector.ldap.Authenticate"/>
-    </sequence>
+<template name="authenticate" xmlns="http://ws.apache.org/ns/synapse">
+  <parameter name="dn"/>
+  <parameter name="password"/>
+  <sequence>
+    <property expression="$func:dn" name="dn" scope="default" type="STRING"/>
+    <property expression="$func:password" name="password"
+      scope="default" type="STRING"/>
+    <class name="org.wso2.carbon.connector.ldap.Authenticate"/>
+  </sequence>
 </template>

--- a/src/main/resources/ldap_auth/authenticate.xml
+++ b/src/main/resources/ldap_auth/authenticate.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+~
+~  WSO2 Inc. licenses this file to you under the Apache License,
+~  Version 2.0 (the "License"); you may not use this file except
+~  in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing,
+~  software distributed under the License is distributed on an
+~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~  KIND, either express or implied.  See the License for the
+~  specific language governing permissions and limitations
+~  under the License.
+-->
 <template name="authenticate" xmlns="http://ws.apache.org/ns/synapse">
   <parameter name="dn"/>
   <parameter name="password"/>

--- a/src/main/resources/ldap_config/init.xml
+++ b/src/main/resources/ldap_config/init.xml
@@ -1,31 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
-~
-~  WSO2 Inc. licenses this file to you under the Apache License,
-~  Version 2.0 (the "License"); you may not use this file except
-~  in compliance with the License.
-~  You may obtain a copy of the License at
-~
-~   http://www.apache.org/licenses/LICENSE-2.0
-~
-~  Unless required by applicable law or agreed to in writing,
-~  software distributed under the License is distributed on an
-~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~  KIND, either express or implied.  See the License for the
-~  specific language governing permissions and limitations
-~  under the License.
--->
-<template xmlns="http://ws.apache.org/ns/synapse" name="init">
-    <parameter name="providerUrl" description="URI of the LDAP directory."/>
-    <parameter name="securityPrincipal"
-               description="username of the user used to log in to LDAP."/>
-    <parameter name="securityCredentials"
-               description="password of the user used to log in to LDAP."/>
-    <sequence>
-        <property name="providerUrl" expression="$func:providerUrl"/>
-        <property name="securityPrincipal" expression="$func:securityPrincipal"/>
-        <property name="securityCredentials" expression="$func:securityCredentials"/>
-        <class name="org.wso2.carbon.connector.ldap.Init"/>
-    </sequence>
+<template name="init" xmlns="http://ws.apache.org/ns/synapse">
+  <parameter name="secureConnection"/>
+  <parameter name="disableSSLCertificateChecking"/>
+  <parameter name="providerUrl"/>
+  <parameter name="securityPrincipal"/>
+  <parameter name="securityCredentials"/>
+  <sequence>
+    <property description="Boolean value for the connection."
+      expression="$func:secureConnection" name="secureConnection"
+      scope="default" type="STRING"/>
+    <property
+      description="Boolean value to whether check certificate or not."
+      expression="$func:disableSSLCertificateChecking"
+      name="disableSSLCertificateChecking" scope="default" type="STRING"/>
+    <property description="URI of the LDAP directory."
+      expression="$func:providerUrl" name="providerUrl" scope="default" type="STRING"/>
+    <property description="Username of the user used to log in to LDAP."
+      expression="$func:securityPrincipal" name="securityPrincipal"
+      scope="default" type="STRING"/>
+    <property description="Password of the user used to log in to LDAP."
+      expression="$func:securityCredentials" name="securityCredentials"
+      scope="default" type="STRING"/>
+    <class name="org.wso2.carbon.connector.ldap.Init"/>
+  </sequence>
 </template>

--- a/src/main/resources/ldap_config/init.xml
+++ b/src/main/resources/ldap_config/init.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+~
+~  WSO2 Inc. licenses this file to you under the Apache License,
+~  Version 2.0 (the "License"); you may not use this file except
+~  in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing,
+~  software distributed under the License is distributed on an
+~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~  KIND, either express or implied.  See the License for the
+~  specific language governing permissions and limitations
+~  under the License.
+-->
 <template name="init" xmlns="http://ws.apache.org/ns/synapse">
   <parameter name="secureConnection"/>
   <parameter name="disableSSLCertificateChecking"/>

--- a/src/main/resources/ldap_entry/addEntry.xml
+++ b/src/main/resources/ldap_entry/addEntry.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+~
+~  WSO2 Inc. licenses this file to you under the Apache License,
+~  Version 2.0 (the "License"); you may not use this file except
+~  in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing,
+~  software distributed under the License is distributed on an
+~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~  KIND, either express or implied.  See the License for the
+~  specific language governing permissions and limitations
+~  under the License.
+-->
 <template name="addEntry" xmlns="http://ws.apache.org/ns/synapse">
   <parameter name="objectClass"/>
   <parameter name="attributes"/>

--- a/src/main/resources/ldap_entry/addEntry.xml
+++ b/src/main/resources/ldap_entry/addEntry.xml
@@ -1,29 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
-~
-~  WSO2 Inc. licenses this file to you under the Apache License,
-~  Version 2.0 (the "License"); you may not use this file except
-~  in compliance with the License.
-~  You may obtain a copy of the License at
-~
-~   http://www.apache.org/licenses/LICENSE-2.0
-~
-~  Unless required by applicable law or agreed to in writing,
-~  software distributed under the License is distributed on an
-~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~  KIND, either express or implied.  See the License for the
-~  specific language governing permissions and limitations
-~  under the License.
--->
-<template xmlns="http://ws.apache.org/ns/synapse" name="addEntry">
-    <parameter name="objectClass"/>
-    <parameter name="attributes"/>
-    <parameter name="dn"/>
-    <sequence>
-        <property name="objectClass" expression="$func:objectClass"/>
-        <property name="attributes" expression="$func:attributes"/>
-        <property name="dn" expression="$func:dn"/>
-        <class name="org.wso2.carbon.connector.ldap.AddEntry"/>
-    </sequence>
+<template name="addEntry" xmlns="http://ws.apache.org/ns/synapse">
+  <parameter name="objectClass"/>
+  <parameter name="attributes"/>
+  <parameter name="dn"/>
+  <sequence>
+    <property expression="$func:objectClass" name="objectClass"
+      scope="default" type="STRING"/>
+    <property expression="$func:attributes" name="attributes"
+      scope="default" type="STRING"/>
+    <property expression="$func:dn" name="dn" scope="default" type="STRING"/>
+    <class name="org.wso2.carbon.connector.ldap.AddEntry"/>
+  </sequence>
 </template>

--- a/src/main/resources/ldap_entry/deleteEntry.xml
+++ b/src/main/resources/ldap_entry/deleteEntry.xml
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
-~
-~  WSO2 Inc. licenses this file to you under the Apache License,
-~  Version 2.0 (the "License"); you may not use this file except
-~  in compliance with the License.
-~  You may obtain a copy of the License at
-~
-~   http://www.apache.org/licenses/LICENSE-2.0
-~
-~  Unless required by applicable law or agreed to in writing,
-~  software distributed under the License is distributed on an
-~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~  KIND, either express or implied.  See the License for the
-~  specific language governing permissions and limitations
-~  under the License.
--->
-<template xmlns="http://ws.apache.org/ns/synapse" name="deleteEntry">
-    <parameter name="dn"/>
-    <sequence>
-        <property name="dn" expression="$func:dn"/>
-        <class name="org.wso2.carbon.connector.ldap.DeleteEntry"/>
-    </sequence>
+<template name="deleteEntry" xmlns="http://ws.apache.org/ns/synapse">
+  <parameter name="dn"/>
+  <sequence>
+    <property expression="$func:dn" name="dn" scope="default" type="STRING"/>
+    <class name="org.wso2.carbon.connector.ldap.DeleteEntry"/>
+  </sequence>
 </template>

--- a/src/main/resources/ldap_entry/deleteEntry.xml
+++ b/src/main/resources/ldap_entry/deleteEntry.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+~
+~  WSO2 Inc. licenses this file to you under the Apache License,
+~  Version 2.0 (the "License"); you may not use this file except
+~  in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing,
+~  software distributed under the License is distributed on an
+~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~  KIND, either express or implied.  See the License for the
+~  specific language governing permissions and limitations
+~  under the License.
+-->
 <template name="deleteEntry" xmlns="http://ws.apache.org/ns/synapse">
   <parameter name="dn"/>
   <sequence>

--- a/src/main/resources/ldap_entry/searchEntry.xml
+++ b/src/main/resources/ldap_entry/searchEntry.xml
@@ -1,31 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
-~
-~  WSO2 Inc. licenses this file to you under the Apache License,
-~  Version 2.0 (the "License"); you may not use this file except
-~  in compliance with the License.
-~  You may obtain a copy of the License at
-~
-~   http://www.apache.org/licenses/LICENSE-2.0
-~
-~  Unless required by applicable law or agreed to in writing,
-~  software distributed under the License is distributed on an
-~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~  KIND, either express or implied.  See the License for the
-~  specific language governing permissions and limitations
-~  under the License.
--->
-<template xmlns="http://ws.apache.org/ns/synapse" name="searchEntry">
-    <parameter name="objectClass"/>
-    <parameter name="filters"/>
-    <parameter name="dn"/>
-    <parameter name="attributes"/>
-    <sequence>
-        <property name="objectClass" expression="$func:objectClass"/>
-        <property name="filters" expression="$func:filters"/>
-        <property name="dn" expression="$func:dn"/>
-        <property name="attributes" expression="$func:attributes"/>
-        <class name="org.wso2.carbon.connector.ldap.SearchEntry"/>
-    </sequence>
+<template name="searchEntry" xmlns="http://ws.apache.org/ns/synapse">
+  <parameter name="onlyOneReference"/>
+  <parameter name="objectClass"/>
+  <parameter name="filters"/>
+  <parameter name="dn"/>
+  <parameter name="attributes"/>
+  <sequence>
+    <property
+      description="Boolean value whether to guarantee or not only one referente"
+      expression="$func:onlyOneReference" name="onlyOneReference"
+      scope="default" type="STRING"/>
+    <property
+      description="The object class of the entry you need to search."
+      expression="$func:objectClass" name="objectClass" scope="default" type="STRING"/>
+    <property
+      description="The keywords to use in the search. The keywords should be specified as comma separated key-value pairs."
+      expression="$func:filters" name="filters" scope="default" type="STRING"/>
+    <property
+      description="The distinguished name of the entry you need to search."
+      expression="$func:dn" name="dn" scope="default" type="STRING"/>
+    <property
+      description="The attributes of the LDAP entry that should be included in the search result."
+      expression="$func:attributes" name="attributes" scope="default" type="STRING"/>
+    <class name="org.wso2.carbon.connector.ldap.SearchEntry"/>
+  </sequence>
 </template>

--- a/src/main/resources/ldap_entry/searchEntry.xml
+++ b/src/main/resources/ldap_entry/searchEntry.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+~
+~  WSO2 Inc. licenses this file to you under the Apache License,
+~  Version 2.0 (the "License"); you may not use this file except
+~  in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing,
+~  software distributed under the License is distributed on an
+~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~  KIND, either express or implied.  See the License for the
+~  specific language governing permissions and limitations
+~  under the License.
+-->
 <template name="searchEntry" xmlns="http://ws.apache.org/ns/synapse">
   <parameter name="onlyOneReference"/>
   <parameter name="objectClass"/>

--- a/src/main/resources/ldap_entry/updateEntry.xml
+++ b/src/main/resources/ldap_entry/updateEntry.xml
@@ -1,29 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
-~
-~  WSO2 Inc. licenses this file to you under the Apache License,
-~  Version 2.0 (the "License"); you may not use this file except
-~  in compliance with the License.
-~  You may obtain a copy of the License at
-~
-~   http://www.apache.org/licenses/LICENSE-2.0
-~
-~  Unless required by applicable law or agreed to in writing,
-~  software distributed under the License is distributed on an
-~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-~  KIND, either express or implied.  See the License for the
-~  specific language governing permissions and limitations
-~  under the License.
--->
-<template xmlns="http://ws.apache.org/ns/synapse" name="updateEntry">
-    <parameter name="attributes"/>
-    <parameter name="dn"/>
-    <parameter name="mode"/>
-    <sequence>
-        <property name="attributes" expression="$func:attributes"/>
-        <property name="dn" expression="$func:dn"/>
-        <property name="mode" expression="$func:mode"/>
-        <class name="org.wso2.carbon.connector.ldap.UpdateEntry"/>
-    </sequence>
+<template name="updateEntry" xmlns="http://ws.apache.org/ns/synapse">
+  <parameter name="attributes"/>
+  <parameter name="dn"/>
+  <parameter name="mode"/>
+  <sequence>
+    <property expression="$func:attributes" name="attributes"
+      scope="default" type="STRING"/>
+    <property expression="$func:dn" name="dn" scope="default" type="STRING"/>
+    <property expression="$func:mode" name="mode" scope="default" type="STRING"/>
+    <class name="org.wso2.carbon.connector.ldap.UpdateEntry"/>
+  </sequence>
 </template>

--- a/src/main/resources/ldap_entry/updateEntry.xml
+++ b/src/main/resources/ldap_entry/updateEntry.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~  Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+~
+~  WSO2 Inc. licenses this file to you under the Apache License,
+~  Version 2.0 (the "License"); you may not use this file except
+~  in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing,
+~  software distributed under the License is distributed on an
+~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~  KIND, either express or implied.  See the License for the
+~  specific language governing permissions and limitations
+~  under the License.
+-->
 <template name="updateEntry" xmlns="http://ws.apache.org/ns/synapse">
   <parameter name="attributes"/>
   <parameter name="dn"/>


### PR DESCRIPTION
I implemented a solution which supports the following configuration:

- **LDAP.init**: Two new parameters (_secureConnection_ and _disableSSLCertificateChecking_) are supported in order to enable secure connection and disable certificate validation. The second parameter is suitable for test environments.
- **LDAP.searchEntry**: The parameter _onlyOneReference_ allows the component, as the name suggests, to return only one reference where there is more than one of it. When such case happens in the component's actual version an exception is raised. See an example below.

```
{
  "result": {
    "status": false,
    "log": {
      "error_message": "Unprocessed Continuation Reference(s)",
      "error_code": 7000001,
      "error_exception": "javax.naming.PartialResultException: Unprocessed Continuation Reference(s); remaining name 'DC=globoprdom,DC=com,DC=br'",
      "error_detail": null
    }
  }
}
```