### PR TITLE
Add support for anonymous bind

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -47,6 +47,11 @@ To use the LDAP connector, add the <ldap.init> element in your configuration bef
 * connectionPoolingInitSize : The string representation of an integer that represents the number of connections per connection identity to create when initially creating a connection for the identity. This is a optional parameter.
 * connectionPoolingMaxSize : The string representation of an integer that represents the maximum number of connections per connection identity that can be maintained concurrently. This is a optional parameter.
 
+### Anonymous bind
+
+In case anonymous bind is accepted by LDAP server configuration, `securityPrincipal` can be omited to initiate the connection with LDAP server without authentication.
+`securityCredentials` parameter is ignored when `securityPrincipal` is not set.
+
 #### Ensuring secure data
 For security purposes, you should store securityCredentials in the WSO2 secure vault and make reference to it by using an alias instead of hard-coding the actual value in the configuration file. For more information, see [Working with Passwords](https://docs.wso2.com/display/EI640/Working+with+Passwords+in+the+ESB+profile).
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,10 +54,10 @@ To use the LDAP connector, add the <ldap.init> element in your configuration bef
 In case anonymous bind is accepted by LDAP server configuration, `securityPrincipal` can be omited to initiate the connection with LDAP server without authentication.
 `securityCredentials` parameter is ignored when `securityPrincipal` is not set.
 
-#### Ensuring secure data
+### Ensuring secure data
 For security purposes, you should store securityCredentials in the WSO2 secure vault and make reference to it by using an alias instead of hard-coding the actual value in the configuration file. For more information, see [Working with Passwords](https://docs.wso2.com/display/EI640/Working+with+Passwords+in+the+ESB+profile).
 
-#### Re-using LDAP configurations
+### Re-using LDAP configurations
 For best results, save the LDAP configuration as a local entry. You can then easily reference it with the configKey attribute in your LDAP operations. For example, if you saved the above <ldap.init> entry as a local entry named ldapConfig,  you could reference it from the deleteEntry operation as follows:
 
 ```xml

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
 # Configuring LDAP Operations
 
-[[Prerequisites]](#Prerequisites) [[Initializing the Connector]](#initializing-the-connector)
+[[Prerequisites]](#prerequisites) [[Initializing the Connector]](#initializing-the-connector)
 
 ## Prerequisites
 
@@ -19,7 +19,9 @@ You can follow the following steps to import your LDAP certificate into wso2esb 
 ## Initializing the Connector
 
 To use the LDAP connector, add the <ldap.init> element in your configuration before performing any other operation. This LDAP configuration authenticates with the LDAP server in order to gain access to perform various LDAP operations.
+
 **init**
+
 ```xml
 <ldap.init>
     <providerUrl>{$ctx:providerUrl}</providerUrl>

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
@@ -66,9 +66,13 @@ public class LDAPUtils {
         Hashtable env = new Hashtable();
         env.put(Context.INITIAL_CONTEXT_FACTORY, LDAPConstants.COM_SUN_JNDI_LDAP_LDAPCTXFACTORY);
         env.put(Context.PROVIDER_URL, providerUrl);
-        env.put(Context.SECURITY_PRINCIPAL, securityPrincipal);
-        env.put(Context.SECURITY_CREDENTIALS, securityCredentials);
         env.put(LDAPConstants.JAVA_NAMING_LDAP_ATTRIBUTE_BINARY, LDAPConstants.OBJECT_GUID);
+
+        // Fallback to anonymous binding when no credentials are provided
+        if (StringUtils.isNotEmpty(securityPrincipal)) {
+            env.put(Context.SECURITY_PRINCIPAL, securityPrincipal);
+            env.put(Context.SECURITY_CREDENTIALS, securityCredentials);
+        }
 
         if(StringUtils.isNotEmpty(timeout)) {
             env.put(LDAPConstants.COM_JAVA_JNDI_LDAP_READ_TIMEOUT, timeout);


### PR DESCRIPTION
In case no securityPrincipal is provided in configuration, omit Context.SECURITY_PRINCIPAL and Context.SECURITY_CREDENTIALS in env hashtable

## Purpose
Implement #50 : support for anonymous bind

## Goals

This feature will permit connection to LDAP directory without securityPrincipal

## Approach

Check if `securityPrincipal` is set in connector configuration before adding it to environment contextFactory.  If option is absent, do not add either `securityPrincipal` nor `securityCredentials` to context. JNDI API will automatically fallback to anonymous bind

## User stories
N/A

## Release note

Add support for anonymous bind

## Documentation


[Connector configuration](docs/config.md)

## Training

N/A

## Certification

N/A

## Marketing

N/1

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**/~~no~~
 - Ran FindSecurityBugs plugin and verified report? ~~yes~~/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**/~~no~~

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment

* Integration Studio 8
* Latest LDAP connector
 
## Learning

[JNDI APIs tutorials](https://docs.oracle.com/javase/tutorial/jndi/ldap/authentication.html) shows how to implement anonymous bind