### PR TITLE
Add operation to rename CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The LDAP [Connector](https://docs.wso2.com/display/EI650/Working+with+Connectors
 
 | Connector version  | Supported WSO2 ESB/EI version |
 | ------------- | ------------- |
+| [1.0.12](https://github.com/wso2-extensions/esb-connector-ldap/tree/org.wso2.carbon.connector.ldap-1.0.12) | EI 6.4.0, EI 7.x    |
 | [1.0.11](https://github.com/wso2-extensions/esb-connector-ldap/tree/org.wso2.carbon.connector.ldap-1.0.11) | EI 7.x    |
 | [1.0.10](https://github.com/wso2-extensions/esb-connector-ldap/tree/org.wso2.carbon.connector.ldap-1.0.10) | EI 6.4.0, EI 6.5.0    |
 | [1.0.9](https://github.com/wso2-extensions/esb-connector-ldap/tree/org.wso2.carbon.connector.ldap-1.0.9) | ESB 4.9.0, EI 6.5.0    |

--- a/docs/crud_ops.md
+++ b/docs/crud_ops.md
@@ -13,6 +13,7 @@ For a sample proxy service that illustrates how to work with each operation, see
 | [searchEntry](#searching-a-ldap-entry)      | Performs a search for one or more LDAP entities with the specified search keys.  |
 | [updateEntry](#updating-a-ldap-entry)    | Updates an existing LDAP entry in the LDAP server. |
 | [deleteEntry](#deleting-a-ldap-entry)    | Deletes an existing LDAP entry from the LDAP server.    |
+| [updateName](#updating-a-ldap-common-name)    | Updates an existing ldap Common Name (CN).    |
 
 ### Operation details
 
@@ -320,6 +321,50 @@ curl http://localhost:8280/services/addEntry -H "Content-Type: application/json"
 ```
 5. LDAP returns an json response similar to the one shown below:
  
+```json
+{"result":{"message":"Success"}}
+```
+
+#### Updating a LDAP Common Name
+
+The updateName operation updates existing ldap Common Name (CN).
+
+**updateName**
+```xml
+<ldap.updateName>
+   <oldName>CN=oldName, CN=Computers,DC=wso2,DC=test</oldName>
+   <newName>CN=updatedName, CN=Computers,DC=wso2,DC=test</newName>
+</ldap.updateName>
+```
+
+**Properties**
+* oldName : Fully qualified existing common name (CN) that is to be updated.
+* newName : Fully qualified new common name (CN).
+
+**Sample request**
+
+Following is a sample request that can be handled by the updateName operation.
+
+```json
+{ 
+   "providerUrl":"ldap://localhost:10389/",
+   "securityPrincipal":"cn=admin,dc=wso2,dc=com",
+   "securityCredentials":"comadmin",
+   "secureConnection":"false",
+   "disableSSLCertificateChecking":"false",
+   "application":"ldap",
+   "operation":"createEntity",
+   "content":{ 
+      "oldName":"CN=oldName, CN=Computers,DC=wso2,DC=test",
+      "newName":"CN=updatedName, CN=Computers,DC=wso2,DC=test"
+   }
+}
+```
+
+**Sample response**
+
+Given below is a sample response for the updateName operation.
+
 ```json
 {"result":{"message":"Success"}}
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.ldap</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.12-SNAPSHOT</version>
+    <version>1.0.12</version>
     <name>WSO2 Carbon - Mediation Library Connector For LDAP</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
@@ -66,6 +66,8 @@ public class LDAPConstants {
     public static final String CONNECTION_POOLING_MAX_SIZE = "connectionPoolingMaxSize";
     public static final String COM_JAVA_JNDI_LDAP_READ_TIMEOUT = "com.sun.jndi.ldap.read.timeout";
     public static final String TIMEOUT = "timeout";
+    public static final String OLD_NAME = "oldName";
+    public static final String NEW_NAME = "newName";
 
     public static final class ErrorConstants {
         public static final int SEARCH_ERROR = 7000001;
@@ -74,6 +76,7 @@ public class LDAPConstants {
         public static final int UPDATE_ENTRY_ERROR = 7000004;
         public static final int DELETE_ENTRY_ERROR = 7000005;
         public static final int ENTRY_DOESNOT_EXISTS_ERROR = 7000006;
+        public static final int RENAME_ERROR = 7000007;
 
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/ldap/Rename.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/Rename.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.wso2.carbon.connector.ldap;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.axiom.om.OMNamespace;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseException;
+import org.wso2.carbon.connector.core.AbstractConnector;
+
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+
+public class Rename extends AbstractConnector {
+
+    @Override
+    public void connect(MessageContext messageContext) {
+
+        String oldName = (String) getParameter(messageContext, LDAPConstants.OLD_NAME);
+        String newName = (String) getParameter(messageContext, LDAPConstants.NEW_NAME);
+
+        OMFactory factory = OMAbstractFactory.getOMFactory();
+        OMNamespace ns = factory.createOMNamespace(LDAPConstants.CONNECTOR_NAMESPACE, LDAPConstants.NAMESPACE);
+        OMElement result = factory.createOMElement(LDAPConstants.RESULT, ns);
+        OMElement message = factory.createOMElement(LDAPConstants.MESSAGE, ns);
+
+        try {
+            DirContext context = LDAPUtils.getDirectoryContext(messageContext);
+            context.rename(oldName, newName);
+            message.setText(LDAPConstants.SUCCESS);
+            result.addChild(message);
+            LDAPUtils.preparePayload(messageContext, result);
+        } catch (NamingException e) {
+            log.error("Failed to update ldap Common Name (CN) ", e);
+            LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.RENAME_ERROR, e);
+            throw new SynapseException(e);
+        }
+    }
+}

--- a/src/main/resources/ldap_entry/component.xml
+++ b/src/main/resources/ldap_entry/component.xml
@@ -30,6 +30,10 @@
             <file>updateEntry.xml</file>
             <description>This updates entries in ldap directory</description>
         </component>
+        <component name="updateName">
+            <file>updateName.xml</file>
+            <description>This updates names in ldap directory</description>
+        </component>
         <component name="deleteEntry">
             <file>deleteEntry.xml</file>
             <description>This deletes entries in ldap directory</description>

--- a/src/main/resources/ldap_entry/updateName.xml
+++ b/src/main/resources/ldap_entry/updateName.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~  Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+~
+~  WSO2 Inc. licenses this file to you under the Apache License,
+~  Version 2.0 (the "License"); you may not use this file except
+~  in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing,
+~  software distributed under the License is distributed on an
+~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~  KIND, either express or implied.  See the License for the
+~  specific language governing permissions and limitations
+~  under the License.
+-->
+<template name="updateName" xmlns="http://ws.apache.org/ns/synapse">
+    <parameter name="oldName" description="Fully qualified old name"/>
+    <parameter name="newName" description="Fully qualified new name"/>
+    <sequence>
+        <property expression="$func:oldName" name="oldName" scope="default" type="STRING"/>
+        <property expression="$func:newName" name="newName" scope="default" type="STRING"/>
+        <class name="org.wso2.carbon.connector.ldap.Rename"/>
+    </sequence>
+</template>

--- a/src/test/java/org/wso2/carbon/connector/unit/test/ldap/RenameTest.java
+++ b/src/test/java/org/wso2/carbon/connector/unit/test/ldap/RenameTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.carbon.connector.unit.test.ldap;
+
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.mediators.template.TemplateContext;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.connector.ldap.Init;
+import org.wso2.carbon.connector.ldap.LDAPConstants;
+import org.wso2.carbon.connector.ldap.Rename;
+
+import java.util.Stack;
+
+public class RenameTest {
+
+    private Rename rename;
+    private Init init;
+    private TemplateContext templateContext;
+    private MessageContext messageContext;
+    private Stack functionStack;
+    private LdapServerSetup ldap;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        ldap = new LdapServerSetup();
+        rename = new Rename();
+        init = new Init();
+        ldap.initializeProperties();
+        if (ldap.useEmbeddedLDAP) {
+            ldap.initializeEmbeddedLDAPServer();
+        }
+        messageContext = ldap.createMessageContext();
+        messageContext.setProperty(LDAPConstants.SECURE_CONNECTION, "false");
+        messageContext.setProperty(LDAPConstants.DISABLE_SSL_CERT_CHECKING, "false");
+        templateContext = new TemplateContext("rename", null);
+        templateContext.getMappedValues().put(LDAPConstants.PROVIDER_URL, "ldap://localhost:10389/");
+        templateContext.getMappedValues().put(LDAPConstants.SECURITY_PRINCIPAL, "cn=admin,dc=wso2,dc=com");
+        templateContext.getMappedValues().put(LDAPConstants.SECURITY_CREDENTIALS, "19902");
+        templateContext.getMappedValues().put(LDAPConstants.OLD_NAME, "uid=john004,ou=People,dc=wso2,dc=com");
+        templateContext.getMappedValues().put(LDAPConstants.NEW_NAME, "uid=john005,ou=People,dc=wso2,dc=com");
+        functionStack = new Stack();
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        ldap.createSampleEntity();
+        try {
+            functionStack.push(templateContext);
+            messageContext.setProperty("_SYNAPSE_FUNCTION_STACK", functionStack);
+            init.connect(messageContext);
+            rename.connect(messageContext);
+            Assert.assertEquals((messageContext.getEnvelope().getBody().getFirstElement()).getFirstElement().getText(), "Success");
+        } finally {
+            ldap.deleteSampleEntry();
+        }
+    }
+
+    @AfterMethod
+    protected void cleanup() {
+        ldap.cleanup();
+    }
+}


### PR DESCRIPTION
## Purpose
This PR adds updateName operation to update Common Name (CN).
Example config:
```
<inSequence>
       <ldap.updateName>
           <oldName>CN=oldName, CN=Computers,DC=wso2,DC=test</oldName>
           <newName>CN=updatedName, CN=Computers,DC=wso2,DC=test</newName>
       </ldap.updateName>
       <respond/>
</inSequence>
```
Fixes https://github.com/wso2/micro-integrator/issues/2509

