### PR TITLE
Add improvement to Search to allow Empty Result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.ldap</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <name>WSO2 Carbon - Mediation Library Connector For LDAP</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
@@ -68,6 +68,7 @@ public class LDAPConstants {
     public static final String TIMEOUT = "timeout";
     public static final String OLD_NAME = "oldName";
     public static final String NEW_NAME = "newName";
+    public static final String ALLOW_EMPTY_SEARCH_RESULT = "allowEmptySearchResult";
 
     public static final class ErrorConstants {
         public static final int SEARCH_ERROR = 7000001;

--- a/src/main/resources/ldap_entry/searchEntry.xml
+++ b/src/main/resources/ldap_entry/searchEntry.xml
@@ -29,6 +29,8 @@
     <parameter name="attributes"
                description="The attributes of the LDAP entry that should be included in the search
                result."/>
+    <parameter name="allowEmptySearchResult"
+               description="Boolean value to allow empty Search Result or throw Exception"/>
     <sequence>
         <property expression="$func:onlyOneReference" name="onlyOneReference" scope="default"
                   type="STRING"/>
@@ -37,6 +39,8 @@
         <property expression="$func:dn" name="dn" scope="default" type="STRING"/>
         <property expression="$func:attributes" name="attributes" scope="default" type="STRING"/>
         <property expression="$func:limit" name="limit" scope="default" type="STRING"/>
+        <property expression="$func:allowEmptySearchResult" name="allowEmptySearchResult" scope="default"
+                  type="STRING"/>
 
         <class name="org.wso2.carbon.connector.ldap.SearchEntry"/>
     </sequence>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Resolves https://github.com/wso2/product-ei/issues/4598

As per default behaviour, when the LDAP search is returned empty, an error will be thrown and the fault sequence will be executed. There can be scenarios where the empty result is expected. Hence a new parameter `allowEmptySearchResult` has been introduced to handle empty results and return null result as below instead of executing the fault sequence.

JSON : `{"result":null}`
XML : `<ns:result xmlns:ns="http://org.wso2.esbconnectors.ldap"/>`