### PR TITLE
Add RFC 2696 Simple Paged Results support to searchEntry 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.wso2.integration.connector</groupId>
     <artifactId>mi-connector-ldap</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.14</version>
+    <version>1.0.15-SNAPSHOT</version>
     <name>WSO2 Carbon - Mediation Library Connector For LDAP</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
@@ -69,6 +69,7 @@ public class LDAPConstants {
     public static final String OLD_NAME = "oldName";
     public static final String NEW_NAME = "newName";
     public static final String ALLOW_EMPTY_SEARCH_RESULT = "allowEmptySearchResult";
+    public static final String PAGE_SIZE = "pageSize";
 
     public static final class ErrorConstants {
         public static final int SEARCH_ERROR = 7000001;

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
@@ -25,6 +25,8 @@ import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
@@ -46,6 +48,15 @@ public class LDAPUtils {
 
     protected static DirContext getDirectoryContext(MessageContext messageContext)
             throws NamingException {
+        return new InitialDirContext(buildEnvironment(messageContext));
+    }
+
+    protected static LdapContext getLdapContext(MessageContext messageContext)
+            throws NamingException {
+        return new InitialLdapContext(buildEnvironment(messageContext), null);
+    }
+
+    private static Hashtable<String, String> buildEnvironment(MessageContext messageContext) {
         String providerUrl = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.PROVIDER_URL);
         String securityPrincipal = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURITY_PRINCIPAL);
         String securityCredentials = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURITY_CREDENTIALS);
@@ -63,14 +74,14 @@ public class LDAPUtils {
         String connectionPoolingMaxSize = LDAPUtils
                 .lookupContextParams(messageContext, LDAPConstants.CONNECTION_POOLING_MAX_SIZE);
 
-        Hashtable env = new Hashtable();
+        Hashtable<String, String> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, LDAPConstants.COM_SUN_JNDI_LDAP_LDAPCTXFACTORY);
         env.put(Context.PROVIDER_URL, providerUrl);
         env.put(Context.SECURITY_PRINCIPAL, securityPrincipal);
         env.put(Context.SECURITY_CREDENTIALS, securityCredentials);
         env.put(LDAPConstants.JAVA_NAMING_LDAP_ATTRIBUTE_BINARY, LDAPConstants.OBJECT_GUID);
 
-        if(StringUtils.isNotEmpty(timeout)) {
+        if (StringUtils.isNotEmpty(timeout)) {
             env.put(LDAPConstants.COM_JAVA_JNDI_LDAP_READ_TIMEOUT, timeout);
         }
         if (secureConnection) {
@@ -92,10 +103,7 @@ public class LDAPUtils {
                 env.put(LDAPConstants.COM_SUN_JNDI_LDAP_CONNECT_POOL_MAXSIZE, connectionPoolingMaxSize);
             }
         }
-
-        DirContext ctx = null;
-        ctx = new InitialDirContext(env);
-        return ctx;
+        return env;
     }
 
     public static String lookupContextParams(MessageContext ctxt, String paramName) {

--- a/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
@@ -95,27 +95,38 @@ public class SearchEntry extends AbstractConnector {
                     handleException("Invalid value for pageSize: " + pageSizeStr, ex, messageContext);
                     return;
                 }
+                if (pageSize <= 0) {
+                    handleException("pageSize must be a positive integer, got: " + pageSize, messageContext);
+                    return;
+                }
 
                 LdapContext ldapContext = LDAPUtils.getLdapContext(messageContext);
                 try {
                     byte[] cookie = null;
                     boolean hasResults = false;
+                    int totalCollected = 0;
+                    boolean limitReached = false;
                     do {
                         ldapContext.setRequestControls(new Control[]{
                                 new PagedResultsControl(pageSize, cookie, Control.CRITICAL)
                         });
                         NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter,
-                                returnAttributes, searchScope, ldapContext, limit);
+                                returnAttributes, searchScope, ldapContext, 0);
                         if (results != null) {
                             while (results.hasMoreElements()) {
                                 hasResults = true;
                                 SearchResult entityResult = results.next();
                                 processObjectGuid(entityResult);
                                 result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
+                                totalCollected++;
+                                if (limit > 0 && totalCollected >= limit) {
+                                    limitReached = true;
+                                    break;
+                                }
                             }
                         }
                         cookie = extractPagedCookie(ldapContext);
-                    } while (cookie != null && cookie.length > 0);
+                    } while (!limitReached && cookie != null && cookie.length > 0);
 
                     if (!hasResults && !allowEmptySearchResult) {
                         throw new NamingException("No matching result or entity found for this search");

--- a/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
@@ -18,6 +18,10 @@
 
 package org.wso2.carbon.connector.ldap;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
@@ -25,22 +29,23 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.PagedResultsControl;
+import javax.naming.ldap.PagedResultsResponseControl;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
-import org.apache.commons.logging.Log;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wso2.carbon.connector.core.AbstractConnector;
-
-import java.nio.ByteBuffer;
-import java.util.Iterator;
 
 public class SearchEntry extends AbstractConnector {
     protected static Log log = LogFactory.getLog(SearchEntry.class);
@@ -50,7 +55,7 @@ public class SearchEntry extends AbstractConnector {
         String objectClass = (String) getParameter(messageContext, LDAPConstants.OBJECT_CLASS);
         String filter = (String) getParameter(messageContext, LDAPConstants.FILTERS);
         String dn = (String) getParameter(messageContext, LDAPConstants.DN);
-        String returnAttributes[] = {};
+        String[] returnAttributes = {};
         String returnAttributesValue = (String) getParameter(messageContext, LDAPConstants.ATTRIBUTES);
         if (!(returnAttributesValue == null || returnAttributesValue.isEmpty())) {
             returnAttributes = returnAttributesValue.split(",");
@@ -66,71 +71,130 @@ public class SearchEntry extends AbstractConnector {
                 log.error("Invalid value specified for Search limit. Setting default limit value of 0 (unlimited)");
             }
         }
-
         boolean onlyOneReference = Boolean.parseBoolean(
                 (String) getParameter(messageContext, LDAPConstants.ONLY_ONE_REFERENCE));
         boolean allowEmptySearchResult = Boolean.parseBoolean(
                 (String) getParameter(messageContext, LDAPConstants.ALLOW_EMPTY_SEARCH_RESULT));
+        String pageSizeStr = (String) getParameter(messageContext, LDAPConstants.PAGE_SIZE);
+
         OMFactory factory = OMAbstractFactory.getOMFactory();
-        OMNamespace ns = factory.createOMNamespace(LDAPConstants.CONNECTOR_NAMESPACE,
-                LDAPConstants.NAMESPACE);
+        OMNamespace ns = factory.createOMNamespace(LDAPConstants.CONNECTOR_NAMESPACE, LDAPConstants.NAMESPACE);
         OMElement result = factory.createOMElement(LDAPConstants.RESULT, ns);
+
         try {
-            DirContext context = LDAPUtils.getDirectoryContext(messageContext);
             String searchFilter = generateSearchFilter(objectClass, filter, messageContext);
-            try {
-                NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter, returnAttributes,
-                                                                           searchScope, context, limit);
-                SearchResult entityResult;
-                if (!onlyOneReference) {
-                    if (results != null && results.hasMore()) {
-                        while (results.hasMoreElements()) {
-                            entityResult = results.next();
-                            Attributes attributes = entityResult.getAttributes();
-                            if (attributes != null) {
-                                Attribute attribute = attributes.get(LDAPConstants.OBJECT_GUID);
-                                if (attribute != null) {
 
-                                    Object attObject = attribute.get(0);
-                                    final byte[] bytes = (byte[]) attObject;
+            if (!StringUtils.isEmpty(pageSizeStr)) {
+                // RFC 2696: fetch all pages on a single connection and return the full result set.
+                // Paging is internal — it exists to satisfy server-side size limits (e.g. AD's 1000
+                // entry cap) without requiring the caller to manage stateful cookies across calls.
+                int pageSize;
+                try {
+                    pageSize = Integer.parseInt(pageSizeStr);
+                } catch (NumberFormatException ex) {
+                    handleException("Invalid value for pageSize: " + pageSizeStr, ex, messageContext);
+                    return;
+                }
 
-                                    // https://community.oracle.com/thread/1157698
-                                    // Represent objectGUID in UUID
-                                    if (bytes.length == 16) {
-                                        final ByteBuffer bb = ByteBuffer.wrap(swapBytes(bytes));
-                                        String attr = new java.util.UUID(bb.getLong(), bb.getLong()).toString();
-                                        entityResult.getAttributes().put(LDAPConstants.OBJECT_GUID, attr);
-                                    }
-                                }
+                LdapContext ldapContext = LDAPUtils.getLdapContext(messageContext);
+                try {
+                    byte[] cookie = null;
+                    boolean hasResults = false;
+                    do {
+                        ldapContext.setRequestControls(new Control[]{
+                                new PagedResultsControl(pageSize, cookie, Control.CRITICAL)
+                        });
+                        NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter,
+                                returnAttributes, searchScope, ldapContext, limit);
+                        if (results != null) {
+                            while (results.hasMoreElements()) {
+                                hasResults = true;
+                                SearchResult entityResult = results.next();
+                                processObjectGuid(entityResult);
+                                result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
                             }
-
-                            result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
                         }
-                    } else {
-                        if (!allowEmptySearchResult) {
+                        cookie = extractPagedCookie(ldapContext);
+                    } while (cookie != null && cookie.length > 0);
+
+                    if (!hasResults && !allowEmptySearchResult) {
+                        throw new NamingException("No matching result or entity found for this search");
+                    }
+                    LDAPUtils.preparePayload(messageContext, result);
+                } catch (NamingException e) {
+                    LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
+                    throw new SynapseException(e);
+                } catch (IOException e) {
+                    LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
+                    throw new SynapseException(e);
+                } finally {
+                    try { ldapContext.close(); } catch (NamingException ignored) {}
+                }
+            } else {
+                // Standard non-paged search
+                DirContext context = LDAPUtils.getDirectoryContext(messageContext);
+                try {
+                    NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter,
+                            returnAttributes, searchScope, context, limit);
+                    if (!onlyOneReference) {
+                        if (results != null && results.hasMore()) {
+                            while (results.hasMoreElements()) {
+                                SearchResult entityResult = results.next();
+                                processObjectGuid(entityResult);
+                                result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
+                            }
+                        } else if (!allowEmptySearchResult) {
                             throw new NamingException("No matching result or entity found for this search");
                         }
+                    } else {
+                        SearchResult entityResult = makeSureOnlyOneMatch(results, allowEmptySearchResult);
+                        result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
                     }
-                } else {
-                    entityResult = makeSureOnlyOneMatch(results, allowEmptySearchResult);
-                    result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
+                    LDAPUtils.preparePayload(messageContext, result);
+                } catch (NamingException e) {
+                    LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
+                    throw new SynapseException(e);
+                } finally {
+                    try { context.close(); } catch (NamingException ignored) {}
                 }
-                LDAPUtils.preparePayload(messageContext, result);
-                if (context != null) {
-                    context.close();
-                }
-            } catch (NamingException e) { //LDAP Errors are catched
-                LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
-                throw new SynapseException(e);
             }
-        } catch (NamingException e) { //Authentication failures are catched
+        } catch (NamingException e) { // Authentication failures from getLdapContext/getDirectoryContext
             LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.INVALID_LDAP_CREDENTIALS, e);
             throw new SynapseException(e);
         }
     }
 
-    private OMElement prepareNode(SearchResult entityResult, OMFactory factory, OMNamespace ns, String returnAttributes[])
-            throws NamingException {
+    private void processObjectGuid(SearchResult entityResult) throws NamingException {
+        Attributes attributes = entityResult.getAttributes();
+        if (attributes != null) {
+            Attribute attribute = attributes.get(LDAPConstants.OBJECT_GUID);
+            if (attribute != null) {
+                Object attObject = attribute.get(0);
+                final byte[] bytes = (byte[]) attObject;
+                // https://community.oracle.com/thread/1157698 — objectGUID bytes are not big-endian
+                if (bytes.length == 16) {
+                    final ByteBuffer bb = ByteBuffer.wrap(swapBytes(bytes));
+                    String attr = new java.util.UUID(bb.getLong(), bb.getLong()).toString();
+                    entityResult.getAttributes().put(LDAPConstants.OBJECT_GUID, attr);
+                }
+            }
+        }
+    }
+
+    private byte[] extractPagedCookie(LdapContext ldapContext) throws NamingException {
+        Control[] responseControls = ldapContext.getResponseControls();
+        if (responseControls != null) {
+            for (Control control : responseControls) {
+                if (control instanceof PagedResultsResponseControl) {
+                    return ((PagedResultsResponseControl) control).getCookie();
+                }
+            }
+        }
+        return null;
+    }
+
+    private OMElement prepareNode(SearchResult entityResult, OMFactory factory, OMNamespace ns,
+                                  String[] returnAttributes) throws NamingException {
         Attributes attributes = entityResult.getAttributes();
         Attribute attribute;
         OMElement entry = factory.createOMElement(LDAPConstants.ENTRY, ns);
@@ -242,17 +306,13 @@ public class SearchEntry extends AbstractConnector {
                                                              String[] returningAttributes,
                                                              int searchScope, DirContext rootContext, int limit)
             throws NamingException {
-        String userBase = dn;
         SearchControls userSearchControl = new SearchControls();
         if (returningAttributes.length > 0) {
             userSearchControl.setReturningAttributes(returningAttributes);
         }
         userSearchControl.setCountLimit(limit);
         userSearchControl.setSearchScope(searchScope);
-        NamingEnumeration<SearchResult> userSearchResults;
-        userSearchResults = rootContext.search(userBase, searchFilter, userSearchControl);
-        return userSearchResults;
-
+        return rootContext.search(dn, searchFilter, userSearchControl);
     }
 
     private String generateSearchFilter(String objectClass, String filter, MessageContext messageContext) {

--- a/src/main/resources/ldap_entry/searchEntry.xml
+++ b/src/main/resources/ldap_entry/searchEntry.xml
@@ -31,6 +31,8 @@
                result."/>
     <parameter name="allowEmptySearchResult"
                description="Boolean value to allow empty Search Result or throw Exception"/>
+    <parameter name="pageSize"
+               description="Number of entries to fetch per page from the server (RFC 2696 Simple Paged Results). Required when the server enforces a size limit (e.g. Active Directory caps results at 1000). Paging is handled internally; the full result set is returned in a single response. Omit or leave empty to disable paging."/>
     <sequence>
         <property expression="$func:onlyOneReference" name="onlyOneReference" scope="default"
                   type="STRING"/>
@@ -41,6 +43,7 @@
         <property expression="$func:limit" name="limit" scope="default" type="STRING"/>
         <property expression="$func:allowEmptySearchResult" name="allowEmptySearchResult" scope="default"
                   type="STRING"/>
+        <property expression="$func:pageSize" name="pageSize" scope="default" type="STRING"/>
 
         <class name="org.wso2.carbon.connector.ldap.SearchEntry"/>
     </sequence>

--- a/src/test/java/org/wso2/carbon/connector/unit/test/ldap/SearchEntryTest.java
+++ b/src/test/java/org/wso2/carbon/connector/unit/test/ldap/SearchEntryTest.java
@@ -149,6 +149,28 @@ public class SearchEntryTest {
         }
     }
 
+    @Test
+    public void testPagedSearch() throws Exception {
+        ldap.createSampleEntity();
+        try {
+            templateContext.getMappedValues().put(LDAPConstants.FILTERS, "{}");
+            templateContext.getMappedValues().put(LDAPConstants.OBJECT_CLASS, "inetOrgPerson");
+            templateContext.getMappedValues().put(LDAPConstants.PAGE_SIZE, "10");
+            functionStack.push(templateContext);
+            messageContext.setProperty("_SYNAPSE_FUNCTION_STACK", functionStack);
+            init.connect(messageContext);
+            searchEntry.connect(messageContext);
+            OMElement result = messageContext.getEnvelope().getBody().getFirstElement();
+            Assert.assertNotNull(result);
+            OMElement entry = result.getFirstElement();
+            Assert.assertNotNull(entry);
+            String userId = ((OMElement) (entry.getChildrenWithLocalName("uid")).next()).getText();
+            Assert.assertEquals(userId, ldap.testUserId);
+        } finally {
+            ldap.deleteSampleEntry();
+        }
+    }
+
     @AfterMethod
     protected void cleanup() {
         ldap.cleanup();


### PR DESCRIPTION
## Purpose

Add RFC 2696 Simple Paged Results support to searchEntry.

Introduces a pageSize parameter on the searchEntry operation. When set, the connector uses LdapContext to issue PagedResultsControl requests, looping through all pages on a single connection and returning the complete result set to the caller. This transparently bypasses server-side size limits (e.g. Active Directory's 1000-entry cap) without exposing stateful paging cookies at the API boundary.

**Sample config**

```xml
<ldap.searchEntry>
    <objectClass>inetOrgPerson</objectClass>
    <dn>ou=Users,dc=example,dc=com</dn>
    <attributes>uid</attributes>
    <filters>{'{}'}</filters>
    <pageSize>500</pageSize>
</ldap.searchEntry>
```

Fixes: https://github.com/wso2/product-integrator/issues/1895