### PR TITLE
Add RFC 2696 Simple Paged Results support to searchEntry

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPConstants.java
@@ -71,6 +71,7 @@ public class LDAPConstants {
     public static final String ALLOW_EMPTY_SEARCH_RESULT = "allowEmptySearchResult";
     public static final String UNICODE_PWD_ATTRIBUTE = "unicodePwd";
     public static final String PASSWORD_QUOTE_FORMAT = "\"%s\"";
+    public static final String PAGE_SIZE = "pageSize";
 
     public static final class ErrorConstants {
         public static final int SEARCH_ERROR = 7000001;

--- a/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/LDAPUtils.java
@@ -25,6 +25,8 @@ import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
@@ -47,6 +49,15 @@ public class LDAPUtils {
 
     protected static DirContext getDirectoryContext(MessageContext messageContext)
             throws NamingException {
+        return new InitialDirContext(buildEnvironment(messageContext));
+    }
+
+    protected static LdapContext getLdapContext(MessageContext messageContext)
+            throws NamingException {
+        return new InitialLdapContext(buildEnvironment(messageContext), null);
+    }
+
+    private static Hashtable<String, String> buildEnvironment(MessageContext messageContext) {
         String providerUrl = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.PROVIDER_URL);
         String securityPrincipal = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURITY_PRINCIPAL);
         String securityCredentials = LDAPUtils.lookupContextParams(messageContext, LDAPConstants.SECURITY_CREDENTIALS);
@@ -71,7 +82,7 @@ public class LDAPUtils {
         env.put(Context.SECURITY_CREDENTIALS, securityCredentials);
         env.put(LDAPConstants.JAVA_NAMING_LDAP_ATTRIBUTE_BINARY, LDAPConstants.OBJECT_GUID);
 
-        if(StringUtils.isNotEmpty(timeout)) {
+        if (StringUtils.isNotEmpty(timeout)) {
             env.put(LDAPConstants.COM_JAVA_JNDI_LDAP_READ_TIMEOUT, timeout);
         }
         if (secureConnection) {
@@ -93,7 +104,7 @@ public class LDAPUtils {
                 env.put(LDAPConstants.COM_SUN_JNDI_LDAP_CONNECT_POOL_MAXSIZE, connectionPoolingMaxSize);
             }
         }
-        return new InitialDirContext(env);
+        return env;
     }
 
     public static String lookupContextParams(MessageContext ctxt, String paramName) {

--- a/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
@@ -18,6 +18,10 @@
 
 package org.wso2.carbon.connector.ldap;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
@@ -25,13 +29,17 @@ import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.PagedResultsControl;
+import javax.naming.ldap.PagedResultsResponseControl;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
-import org.apache.commons.logging.Log;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
@@ -39,9 +47,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wso2.integration.connector.core.AbstractConnectorOperation;
 import org.wso2.integration.connector.core.ConnectException;
-
-import java.nio.ByteBuffer;
-import java.util.Iterator;
 
 public class SearchEntry extends AbstractConnectorOperation {
     protected static Log log = LogFactory.getLog(SearchEntry.class);
@@ -67,71 +72,130 @@ public class SearchEntry extends AbstractConnectorOperation {
                 log.error("Invalid value specified for Search limit. Setting default limit value of 0 (unlimited)");
             }
         }
-
         boolean onlyOneReference = Boolean.parseBoolean(
                 (String) getParameter(messageContext, LDAPConstants.ONLY_ONE_REFERENCE));
         boolean allowEmptySearchResult = Boolean.parseBoolean(
                 (String) getParameter(messageContext, LDAPConstants.ALLOW_EMPTY_SEARCH_RESULT));
+        String pageSizeStr = (String) getParameter(messageContext, LDAPConstants.PAGE_SIZE);
+
         OMFactory factory = OMAbstractFactory.getOMFactory();
-        OMNamespace ns = factory.createOMNamespace(LDAPConstants.CONNECTOR_NAMESPACE,
-                LDAPConstants.NAMESPACE);
+        OMNamespace ns = factory.createOMNamespace(LDAPConstants.CONNECTOR_NAMESPACE, LDAPConstants.NAMESPACE);
         OMElement result = factory.createOMElement(LDAPConstants.RESULT, ns);
+
         try {
-            DirContext context = LDAPUtils.getDirectoryContext(messageContext);
             String searchFilter = generateSearchFilter(objectClass, filter, messageContext);
-            try {
-                NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter, returnAttributes,
-                                                                           searchScope, context, limit);
-                SearchResult entityResult;
-                if (!onlyOneReference) {
-                    if (results != null && results.hasMore()) {
-                        while (results.hasMoreElements()) {
-                            entityResult = results.next();
-                            Attributes attributes = entityResult.getAttributes();
-                            if (attributes != null) {
-                                Attribute attribute = attributes.get(LDAPConstants.OBJECT_GUID);
-                                if (attribute != null) {
 
-                                    Object attObject = attribute.get(0);
-                                    final byte[] bytes = (byte[]) attObject;
+            if (!StringUtils.isEmpty(pageSizeStr)) {
+                // RFC 2696: fetch all pages on a single connection and return the full result set.
+                // Paging is internal — it exists to satisfy server-side size limits (e.g. AD's 1000
+                // entry cap) without requiring the caller to manage stateful cookies across calls.
+                int pageSize;
+                try {
+                    pageSize = Integer.parseInt(pageSizeStr);
+                } catch (NumberFormatException ex) {
+                    handleException("Invalid value for pageSize: " + pageSizeStr, ex, messageContext);
+                    return;
+                }
 
-                                    // https://community.oracle.com/thread/1157698
-                                    // Represent objectGUID in UUID
-                                    if (bytes.length == 16) {
-                                        final ByteBuffer bb = ByteBuffer.wrap(swapBytes(bytes));
-                                        String attr = new java.util.UUID(bb.getLong(), bb.getLong()).toString();
-                                        entityResult.getAttributes().put(LDAPConstants.OBJECT_GUID, attr);
-                                    }
-                                }
+                LdapContext ldapContext = LDAPUtils.getLdapContext(messageContext);
+                try {
+                    byte[] cookie = null;
+                    boolean hasResults = false;
+                    do {
+                        ldapContext.setRequestControls(new Control[]{
+                                new PagedResultsControl(pageSize, cookie, Control.CRITICAL)
+                        });
+                        NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter,
+                                returnAttributes, searchScope, ldapContext, limit);
+                        if (results != null) {
+                            while (results.hasMoreElements()) {
+                                hasResults = true;
+                                SearchResult entityResult = results.next();
+                                processObjectGuid(entityResult);
+                                result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
                             }
-
-                            result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
                         }
-                    } else {
-                        if (!allowEmptySearchResult) {
+                        cookie = extractPagedCookie(ldapContext);
+                    } while (cookie != null && cookie.length > 0);
+
+                    if (!hasResults && !allowEmptySearchResult) {
+                        throw new NamingException("No matching result or entity found for this search");
+                    }
+                    LDAPUtils.preparePayload(messageContext, result);
+                } catch (NamingException e) {
+                    LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
+                    throw new SynapseException(e);
+                } catch (IOException e) {
+                    LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
+                    throw new SynapseException(e);
+                } finally {
+                    try { ldapContext.close(); } catch (NamingException ignored) {}
+                }
+            } else {
+                // Standard non-paged search
+                DirContext context = LDAPUtils.getDirectoryContext(messageContext);
+                try {
+                    NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter,
+                            returnAttributes, searchScope, context, limit);
+                    if (!onlyOneReference) {
+                        if (results != null && results.hasMore()) {
+                            while (results.hasMoreElements()) {
+                                SearchResult entityResult = results.next();
+                                processObjectGuid(entityResult);
+                                result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
+                            }
+                        } else if (!allowEmptySearchResult) {
                             throw new NamingException("No matching result or entity found for this search");
                         }
+                    } else {
+                        SearchResult entityResult = makeSureOnlyOneMatch(results, allowEmptySearchResult);
+                        result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
                     }
-                } else {
-                    entityResult = makeSureOnlyOneMatch(results, allowEmptySearchResult);
-                    result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
+                    LDAPUtils.preparePayload(messageContext, result);
+                } catch (NamingException e) {
+                    LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
+                    throw new SynapseException(e);
+                } finally {
+                    try { context.close(); } catch (NamingException ignored) {}
                 }
-                LDAPUtils.preparePayload(messageContext, result);
-                if (context != null) {
-                    context.close();
-                }
-            } catch (NamingException e) { //LDAP Errors are catched
-                LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.SEARCH_ERROR, e);
-                throw new SynapseException(e);
             }
-        } catch (NamingException e) { //Authentication failures are catched
+        } catch (NamingException e) { // Authentication failures from getLdapContext/getDirectoryContext
             LDAPUtils.handleErrorResponse(messageContext, LDAPConstants.ErrorConstants.INVALID_LDAP_CREDENTIALS, e);
             throw new SynapseException(e);
         }
     }
 
-    private OMElement prepareNode(SearchResult entityResult, OMFactory factory, OMNamespace ns, String[] returnAttributes)
-            throws NamingException {
+    private void processObjectGuid(SearchResult entityResult) throws NamingException {
+        Attributes attributes = entityResult.getAttributes();
+        if (attributes != null) {
+            Attribute attribute = attributes.get(LDAPConstants.OBJECT_GUID);
+            if (attribute != null) {
+                Object attObject = attribute.get(0);
+                final byte[] bytes = (byte[]) attObject;
+                // https://community.oracle.com/thread/1157698 — objectGUID bytes are not big-endian
+                if (bytes.length == 16) {
+                    final ByteBuffer bb = ByteBuffer.wrap(swapBytes(bytes));
+                    String attr = new java.util.UUID(bb.getLong(), bb.getLong()).toString();
+                    entityResult.getAttributes().put(LDAPConstants.OBJECT_GUID, attr);
+                }
+            }
+        }
+    }
+
+    private byte[] extractPagedCookie(LdapContext ldapContext) throws NamingException {
+        Control[] responseControls = ldapContext.getResponseControls();
+        if (responseControls != null) {
+            for (Control control : responseControls) {
+                if (control instanceof PagedResultsResponseControl) {
+                    return ((PagedResultsResponseControl) control).getCookie();
+                }
+            }
+        }
+        return null;
+    }
+
+    private OMElement prepareNode(SearchResult entityResult, OMFactory factory, OMNamespace ns,
+                                  String[] returnAttributes) throws NamingException {
         Attributes attributes = entityResult.getAttributes();
         Attribute attribute;
         OMElement entry = factory.createOMElement(LDAPConstants.ENTRY, ns);
@@ -249,9 +313,7 @@ public class SearchEntry extends AbstractConnectorOperation {
         }
         userSearchControl.setCountLimit(limit);
         userSearchControl.setSearchScope(searchScope);
-        NamingEnumeration<SearchResult> userSearchResults;
-        userSearchResults = rootContext.search(dn, searchFilter, userSearchControl);
-        return userSearchResults;
+        return rootContext.search(dn, searchFilter, userSearchControl);
 
     }
 

--- a/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
+++ b/src/main/java/org/wso2/carbon/connector/ldap/SearchEntry.java
@@ -96,27 +96,38 @@ public class SearchEntry extends AbstractConnectorOperation {
                     handleException("Invalid value for pageSize: " + pageSizeStr, ex, messageContext);
                     return;
                 }
+                if (pageSize <= 0) {
+                    handleException("pageSize must be a positive integer, got: " + pageSize, messageContext);
+                    return;
+                }
 
                 LdapContext ldapContext = LDAPUtils.getLdapContext(messageContext);
                 try {
                     byte[] cookie = null;
                     boolean hasResults = false;
+                    int totalCollected = 0;
+                    boolean limitReached = false;
                     do {
                         ldapContext.setRequestControls(new Control[]{
                                 new PagedResultsControl(pageSize, cookie, Control.CRITICAL)
                         });
                         NamingEnumeration<SearchResult> results = searchInUserBase(dn, searchFilter,
-                                returnAttributes, searchScope, ldapContext, limit);
+                                returnAttributes, searchScope, ldapContext, 0);
                         if (results != null) {
                             while (results.hasMoreElements()) {
                                 hasResults = true;
                                 SearchResult entityResult = results.next();
                                 processObjectGuid(entityResult);
                                 result.addChild(prepareNode(entityResult, factory, ns, returnAttributes));
+                                totalCollected++;
+                                if (limit > 0 && totalCollected >= limit) {
+                                    limitReached = true;
+                                    break;
+                                }
                             }
                         }
                         cookie = extractPagedCookie(ldapContext);
-                    } while (cookie != null && cookie.length > 0);
+                    } while (!limitReached && cookie != null && cookie.length > 0);
 
                     if (!hasResults && !allowEmptySearchResult) {
                         throw new NamingException("No matching result or entity found for this search");

--- a/src/main/resources/ldap_entry/searchEntry.xml
+++ b/src/main/resources/ldap_entry/searchEntry.xml
@@ -31,6 +31,8 @@
                result."/>
     <parameter name="allowEmptySearchResult"
                description="Boolean value to allow empty Search Result or throw Exception"/>
+    <parameter name="pageSize"
+               description="Number of entries to fetch per page from the server (RFC 2696 Simple Paged Results). Required when the server enforces a size limit (e.g. Active Directory caps results at 1000). Paging is handled internally; the full result set is returned in a single response. Omit or leave empty to disable paging."/>
     <parameter name="responseVariable" description="The name of the variable to which the response should be stored."/>
     <parameter name="overwriteBody" description="Replace the Message Body in Message Context with the response of the operation."/>
     <sequence>
@@ -43,6 +45,7 @@
         <property expression="$func:limit" name="limit" scope="default" type="STRING"/>
         <property expression="$func:allowEmptySearchResult" name="allowEmptySearchResult" scope="default"
                   type="STRING"/>
+        <property expression="$func:pageSize" name="pageSize" scope="default" type="STRING"/>
 
         <class name="org.wso2.carbon.connector.ldap.SearchEntry"/>
     </sequence>

--- a/src/main/resources/uischema/searchEntry.json
+++ b/src/main/resources/uischema/searchEntry.json
@@ -84,7 +84,18 @@
               "inputType": "stringOrExpression",
               "defaultValue": "10",
               "required": "false",
-              "helpTip": "Maximum number of search results to return. Use 0 for unlimited."
+              "helpTip": "Maximum number of search results to return. Use 0 for unlimited. Ignored when Page Size is set."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "pageSize",
+              "displayName": "Page Size",
+              "inputType": "stringOrExpression",
+              "defaultValue": "",
+              "required": "false",
+              "helpTip": "Number of entries to fetch per page using RFC 2696 Simple Paged Results. Use this to bypass server-side size limits (e.g. Active Directory's default 1000-entry cap). All pages are fetched internally and the full result set is returned. Must be a positive integer. When set, Result Limit and Only One Reference are ignored."
             }
           },
           {
@@ -106,7 +117,7 @@
               "inputType": "checkbox",
               "defaultValue": "false",
               "required": "false",
-              "helpTip": "If true, ensures only one reference is returned."
+              "helpTip": "If true, ensures only one reference is returned. Ignored when Page Size is set."
             }
           },
           {

--- a/src/main/resources/uischema/searchEntry.json
+++ b/src/main/resources/uischema/searchEntry.json
@@ -84,7 +84,7 @@
               "inputType": "stringOrExpression",
               "defaultValue": "10",
               "required": "false",
-              "helpTip": "Maximum number of search results to return. Use 0 for unlimited. Ignored when Page Size is set."
+              "helpTip": "Maximum number of search results to return. Use 0 for unlimited. When Page Size is set, this acts as a total result cap across all pages."
             }
           },
           {
@@ -95,7 +95,7 @@
               "inputType": "stringOrExpression",
               "defaultValue": "",
               "required": "false",
-              "helpTip": "Number of entries to fetch per page using RFC 2696 Simple Paged Results. Use this to bypass server-side size limits (e.g. Active Directory's default 1000-entry cap). All pages are fetched internally and the full result set is returned. Must be a positive integer. When set, Result Limit and Only One Reference are ignored."
+              "helpTip": "Number of entries to fetch per page using RFC 2696 Simple Paged Results. Use this to bypass server-side size limits (e.g. Active Directory's default 1000-entry cap). All pages are fetched internally and the full result set is returned. Must be a positive integer."
             }
           },
           {

--- a/src/test/java/org/wso2/carbon/connector/unit/test/ldap/SearchEntryTest.java
+++ b/src/test/java/org/wso2/carbon/connector/unit/test/ldap/SearchEntryTest.java
@@ -149,6 +149,28 @@ public class SearchEntryTest {
         }
     }
 
+    @Test
+    public void testPagedSearch() throws Exception {
+        ldap.createSampleEntity();
+        try {
+            templateContext.getMappedValues().put(LDAPConstants.FILTERS, "{}");
+            templateContext.getMappedValues().put(LDAPConstants.OBJECT_CLASS, "inetOrgPerson");
+            templateContext.getMappedValues().put(LDAPConstants.PAGE_SIZE, "10");
+            functionStack.push(templateContext);
+            messageContext.setProperty("_SYNAPSE_FUNCTION_STACK", functionStack);
+            init.connect(messageContext);
+            searchEntry.connect(messageContext);
+            OMElement result = messageContext.getEnvelope().getBody().getFirstElement();
+            Assert.assertNotNull(result);
+            OMElement entry = result.getFirstElement();
+            Assert.assertNotNull(entry);
+            String userId = ((OMElement) (entry.getChildrenWithLocalName("uid")).next()).getText();
+            Assert.assertEquals(userId, ldap.testUserId);
+        } finally {
+            ldap.deleteSampleEntry();
+        }
+    }
+
     @AfterMethod
     protected void cleanup() {
         ldap.cleanup();


### PR DESCRIPTION
## Purpose

Add RFC 2696 Simple Paged Results support to searchEntry.

Introduces a pageSize parameter on the searchEntry operation. When set, the connector uses LdapContext to issue PagedResultsControl requests, looping through all pages on a single connection and returning the complete result set to the caller. This transparently bypasses server-side size limits (e.g. Active Directory's 1000-entry cap) without exposing stateful paging cookies at the API boundary.

**Sample config**

```xml
<ldap.searchEntry>
    <objectClass>inetOrgPerson</objectClass>
    <dn>ou=Users,dc=example,dc=com</dn>
    <attributes>uid</attributes>
    <filters>{'{}'}</filters>
    <pageSize>500</pageSize>
</ldap.searchEntry>
```

Fixes: https://github.com/wso2/product-integrator/issues/1895